### PR TITLE
OSS-265 | fix wrong default value for PR title

### DIFF
--- a/branch/action.yml
+++ b/branch/action.yml
@@ -18,7 +18,7 @@ inputs:
   pr_title:
     description: 'If non-empty, checked for Jira key and branch name match'
     required: false
-    default: ''
+    default: None
 outputs:
   jira_issue_key:
     description: 'Jira issue key'


### PR DESCRIPTION
The empty value for pr title broke the check because it evaluates to false.